### PR TITLE
Add GPT2 Implementation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,7 @@
 # API Reference
 
 ::: llmz.datasets
+::: llmz.gpt2
 ::: llmz.components.attention
 ::: llmz.components.normalisation
 ::: llmz.components.activations

--- a/src/llmz/components/attention.py
+++ b/src/llmz/components/attention.py
@@ -5,7 +5,7 @@ from torch import nn
 
 
 class MultiHeadAttention(nn.Module):
-    """Basic attention block."""
+    """Basic causal attention block."""
 
     def __init__(
         self,
@@ -21,7 +21,7 @@ class MultiHeadAttention(nn.Module):
         Args:
             dim_in: Dimension of input word embeddings.
             dim_out: Dimension of output attention embeddings.
-            context_size: The number of input word embeddings in teh sequence.
+            context_size: The number of input word embeddings in the sequence.
             n_heads: The number of attention heads. Defaults to 1.
             dropout: The dropout rate. Defaults to 0.6.
             qkv_bias: Whether or not to include bias in the linear layers used to

--- a/src/llmz/components/attention.py
+++ b/src/llmz/components/attention.py
@@ -83,7 +83,7 @@ class MultiHeadAttention(nn.Module):
 
         # compute attention weights from attention scores (dim = -1 -> last dim in size)
         attn_weights = torch.softmax(attn_scores / keys.size()[-1] ** 0.5, dim=-1)
-        attn_weights = self.dropout(attn_scores)
+        attn_weights = self.dropout(attn_weights)
 
         # compute context embeddings & reshape to batch_size, seq_len, n_heads, head_dim
         context_embeddings = (attn_weights @ values).transpose(1, 2)

--- a/src/llmz/components/transformers.py
+++ b/src/llmz/components/transformers.py
@@ -23,7 +23,7 @@ class TransformerBlockGPT2(nn.Module):
 
         Args:
             dim_in: Dimension of input word embeddings.
-            context_size: The number of input word embeddings in teh sequence.
+            context_size: The number of input word embeddings in the sequence.
             n_heads: The number of attention heads. Defaults to 1.
             dropout: The dropout rate. Defaults to 0.6.
             qkv_bias: Whether or not to include bias in the linear layers used to

--- a/src/llmz/gpt2.py
+++ b/src/llmz/gpt2.py
@@ -1,10 +1,63 @@
 """Implementation of GPT2."""
 
+from collections.abc import Iterator
+from dataclasses import asdict, dataclass
+from typing import Any
+
 import torch
 from torch import nn
 
 from llmz.components.normalisation import LayerNormalisation
 from llmz.components.transformers import TransformerBlockGPT2
+
+
+@dataclass(frozen=True)
+class GPT2Config:
+    """Container class for GPT2 model hyper-parameters.
+
+    Args:
+        vocab_size: The number of unique tokens that the model expects to encounter.
+        embed_dim: Dimension of input word embeddings.
+        context_size: The number of input word embeddings in the sequence.
+        n_tsfmr_blocks: The number of transformer blocks stacked together.
+        n_attn_heads: The number of attention heads in every transformer block.
+            Defaults to 1.
+        dropout: The dropout rate. Defaults to 0.6.
+        qkv_bias: Whether or not to include bias in the linear layers used to
+            compute W_query, W_key and W_value. Defaults to False.
+
+    Raises:
+        GPT2ConfigError: if any int or float parameter is <= 0, or
+            embed_dim % n_attn_heads != 0
+
+    """
+
+    vocab_size: int
+    embed_dim: int
+    context_size: int
+    n_tsfmr_blocks: int = 1
+    n_attn_heads: int = 1
+    dropout: float = 0.6
+    qkv_bias: bool = False
+
+    def __post_init__(self) -> None:
+        """Validate fields after initialisation."""
+        errors: list[str] = [""]
+
+        for field, value in self.__dict__.items():
+            if type(field) in (int, float) and float(field) <= 0.:
+                errors.append(f"{field} is not > 0")
+
+        if self.embed_dim % self.n_attn_heads != 0:
+            errors.append("embed_dim % n_attn_heads != 0")
+
+        if errors:
+            msg = "invalid GPT2 parameters: " + "\n ".join(errors)
+            raise GPT2ConfigError(msg)
+
+    def __iter__(self) -> Iterator[tuple[str, Any]]:
+        """Iterate over fields to enable GPT2 instantiation with **kwargs syntax."""
+        return iter(asdict(self).items())
 
 
 class GPT2(nn.Module):
@@ -75,6 +128,12 @@ class GPT2(nn.Module):
         y = self.final_norm(y)
         logits = self.output_head(y)
         return logits
+
+
+class GPT2ConfigError(Exception):
+    """Custom exception for GPT2 inference errors."""
+
+    pass
 
 
 class GPT2InferenceError(Exception):

--- a/src/llmz/gpt2.py
+++ b/src/llmz/gpt2.py
@@ -1,9 +1,64 @@
 """Implementation of GPT2."""
 
+import torch
 from torch import nn
+
+from llmz.components.normalisation import LayerNormalisation
+from llmz.components.transformers import TransformerBlockGPT2
 
 
 class GPT2(nn.Module):
     """Implementation of OpenAI's GPT2 model."""
 
-    pass
+    def __init__(
+        self,
+        vocab_size: int,
+        embed_dim: int,
+        context_size: int,
+        n_tsfmr_blocks: int = 1,
+        n_attn_heads: int = 1,
+        dropout: float = 0.6,
+        qkv_bias: bool = False,
+    ):
+        """Initialise model.
+
+        Args:
+            vocab_size: The number of unique tokens that the model expects to encounter.
+            embed_dim: Dimension of input word embeddings.
+            context_size: The number of input word embeddings in the sequence.
+            n_tsfmr_blocks: The number of transformer blocks stacked together.
+            n_attn_heads: The number of attention heads in every transformer block.
+                Defaults to 1.
+            dropout: The dropout rate. Defaults to 0.6.
+            qkv_bias: Whether or not to include bias in the linear layers used to
+                compute W_query, W_key and W_value. Defaults to False.
+
+        """
+        super().__init__()
+
+        self.token_embed = nn.Embedding(vocab_size, embed_dim)
+        self.position_embed = nn.Embedding(context_size, embed_dim)
+
+        self.tsfmr_stack = nn.Sequential(
+            *[
+                TransformerBlockGPT2(
+                    context_size, embed_dim, n_attn_heads, dropout, qkv_bias
+                )
+                for _ in range(n_tsfmr_blocks)
+            ]
+        )
+
+        self.final_norm = LayerNormalisation(embed_dim)
+        self.final_out = nn.Linear(embed_dim, vocab_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Execute the module's forward pass.
+
+        Args:
+            x: Batch of token embeddings.
+
+        Returns:
+            Batch of attention weighted embeddings.
+
+        """
+        return x

--- a/src/llmz/gpt2.py
+++ b/src/llmz/gpt2.py
@@ -1,0 +1,9 @@
+"""Implementation of GPT2."""
+
+from torch import nn
+
+
+class GPT2(nn.Module):
+    """Implementation of OpenAI's GPT2 model."""
+
+    pass

--- a/src/llmz/gpt2.py
+++ b/src/llmz/gpt2.py
@@ -3,11 +3,13 @@
 from collections.abc import KeysView
 from dataclasses import asdict, dataclass
 
+import tiktoken
 import torch
 from torch import nn
 
 from llmz.components.normalisation import LayerNormalisation
 from llmz.components.transformers import TransformerBlockGPT2
+from llmz.tokenizers import _Tokenizer
 
 GPT2ConfigValue = int | float | bool
 
@@ -166,6 +168,22 @@ class GPT2(nn.Module):
         y = self.final_norm(y)
         logits = self.output_head(y)
         return logits
+
+
+class GPT2Tokenizer(_Tokenizer):
+    """Pre-trained version of GPT2's tokenizer."""
+
+    def __init__(self) -> None:
+        """Initialise tokenizer."""
+        self._tokenizer = tiktoken.get_encoding("gpt2")
+
+    def text2tokens(self, text: str) -> list[int]:
+        """Map a string to a list of tokens."""
+        return self._tokenizer.encode(text)
+
+    def tokens2text(self, tokens: list[int]) -> str:
+        """Map a list of tokens to a string.."""
+        return self._tokenizer.decode(tokens)
 
 
 class GPT2ConfigError(Exception):

--- a/src/llmz/gpt2.py
+++ b/src/llmz/gpt2.py
@@ -63,9 +63,10 @@ class GPT2(nn.Module):
             Batch of attention weighted embeddings.
 
         """
-        _, seq_len = x.size()
+        seq_len = x.size()[1]
         if seq_len > self.context_size:
-            raise Exception("TODO")
+            msg = f"seq_len ({seq_len}) > context_size ({self.context_size})"
+            raise GPT2InferenceError(msg)
 
         positions = torch.arange(0, seq_len, device=x.device)
         y = self.token_embed(x) + self.position_embed(positions)
@@ -74,3 +75,9 @@ class GPT2(nn.Module):
         y = self.final_norm(y)
         logits = self.output_head(y)
         return logits
+
+
+class GPT2InferenceError(Exception):
+    """Custom exception for GPT2 inference errors."""
+
+    pass

--- a/src/llmz/tokenizers.py
+++ b/src/llmz/tokenizers.py
@@ -16,9 +16,8 @@ class _Tokenizer(ABC):
     def __call__(self, text: str) -> list[int]:
         return self.text2tokens(text)
 
-    @abstractmethod
     def train(self, **kwargs: dict[str, Any]) -> _Tokenizer:
-        pass
+        return self
 
     @abstractmethod
     def text2tokens(self, text: str) -> list[int]:

--- a/src/llmz/tokenizers.py
+++ b/src/llmz/tokenizers.py
@@ -7,7 +7,6 @@ but they will all implement the interface defined here.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any
 
 
 class _Tokenizer(ABC):
@@ -15,9 +14,6 @@ class _Tokenizer(ABC):
 
     def __call__(self, text: str) -> list[int]:
         return self.text2tokens(text)
-
-    def train(self, **kwargs: dict[str, Any]) -> _Tokenizer:
-        return self
 
     @abstractmethod
     def text2tokens(self, text: str) -> list[int]:

--- a/src/llmz/tokenizers.py
+++ b/src/llmz/tokenizers.py
@@ -1,0 +1,29 @@
+"""Tools for tokenizing text.
+
+Individual model definitions may have their own tokenizers defined alongside them,
+but they will all implement the interface defined here.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class _Tokenizer(ABC):
+    """Abstract base class for text tokenizers."""
+
+    def __call__(self, text: str) -> list[int]:
+        return self.text2tokens(text)
+
+    @abstractmethod
+    def train(self, **kwargs: dict[str, Any]) -> _Tokenizer:
+        pass
+
+    @abstractmethod
+    def text2tokens(self, text: str) -> list[int]:
+        pass
+
+    @abstractmethod
+    def tokens2text(self, token: list[int]) -> str:
+        pass

--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -11,7 +11,7 @@ from llmz.components.attention import ModelConfigError, MultiHeadAttention
     "batch_size, context_size, dim_in, dim_out",
     [(1, 2, 9, 9), (1, 2, 9, 5), (2, 4, 9, 3)],
 )
-def test_Attention_output_size(
+def test_Attention_output_properties(
     batch_size: int, context_size: int, dim_in: int, dim_out: int
 ):
     tokens_batch = torch.ones(batch_size, context_size, dtype=torch.int32)
@@ -21,6 +21,7 @@ def test_Attention_output_size(
     out_batch = attention(embeddings_batch)
 
     assert out_batch.size() == torch.Size((batch_size, context_size, dim_out))
+    assert torch.all(torch.isreal(out_batch))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_gpt2.py
+++ b/tests/test_gpt2.py
@@ -1,0 +1,8 @@
+"""Test for GP2 model."""
+
+from llmz.gpt2 import GPT2
+
+
+def test_GPT2_output_shape():
+    model = GPT2()
+    assert model is not None

--- a/tests/test_gpt2.py
+++ b/tests/test_gpt2.py
@@ -69,16 +69,45 @@ def test_GPT2Config_validates_fields():
             qkv_bias=False,
         )
 
+
 def test_GPT2Config_kwarg_expansion():
-        try:
-            config = GPT2Config(
-                vocab_size=1000,
-                embed_dim=800,
-                context_size=100,
-                n_tsfmr_blocks=4,
-                n_attn_heads=8,
-            )
-            GPT2(**config)
-            assert True
-        except Exception:
-            assert False
+    try:
+        config = GPT2Config(
+            vocab_size=1000,
+            embed_dim=800,
+            context_size=100,
+            n_tsfmr_blocks=4,
+            n_attn_heads=8,
+        )
+        GPT2(**config)
+        assert True
+    except Exception:
+        assert False
+
+
+def test_GPT2Config_string_representation():
+    config = GPT2Config(
+        vocab_size=1000,
+        embed_dim=800,
+        context_size=100,
+        n_tsfmr_blocks=4,
+        n_attn_heads=8,
+    )
+    expected_output_pattern = (
+        r"GPT2Config\(([a-zA-Z0-9_]+=([\.\d]+|True|False|\".*\")(,\s|))+\)$"
+    )
+    assert re.match(expected_output_pattern, str(config)) is not None
+
+
+def test_GPT2Config_command_line_representation():
+    config = GPT2Config(
+        vocab_size=1000,
+        embed_dim=800,
+        context_size=100,
+        n_tsfmr_blocks=4,
+        n_attn_heads=8,
+    )
+    expected_output_pattern = (
+        r"^GPT2Config\(\n(\s\s[a-zA-Z0-9_]+=([\.\d]+|True|False|\".*\")+,\n)+\)$"
+    )
+    assert re.match(expected_output_pattern, config.__repr__()) is not None

--- a/tests/test_gpt2.py
+++ b/tests/test_gpt2.py
@@ -5,7 +5,13 @@ import re
 import pytest
 import torch
 
-from llmz.gpt2 import GPT2, GPT2Config, GPT2ConfigError, GPT2InferenceError, GPT2Tokenizer
+from llmz.gpt2 import (
+    GPT2,
+    GPT2Config,
+    GPT2ConfigError,
+    GPT2InferenceError,
+    GPT2Tokenizer,
+)
 
 
 @pytest.mark.parametrize(
@@ -117,6 +123,12 @@ def test_GPT2Config_command_line_representation():
 def test_GP2Tokenizer_tokenizes_text(text: str):
     tokenizer = GPT2Tokenizer()
     tokens = tokenizer.text2tokens(text)
+
     assert len(tokens) > 1
     assert isinstance(tokens[0], int)
+
+    assert tokenizer.text2tokens(text) == tokens
     assert tokenizer.tokens2text(tokens) == text
+
+    assert tokenizer(text) == tokenizer.text2tokens(text)
+    assert tokenizer.train() is tokenizer

--- a/tests/test_gpt2.py
+++ b/tests/test_gpt2.py
@@ -8,9 +8,9 @@ from llmz.gpt2 import GPT2
 
 @pytest.mark.parametrize(
     "vocab_size, batch_size, context_size, embed_dim, n_tsfmr_blocks",
-    [(10, 1, 2, 9, 1), (20, 1, 2, 9, 2), (27, 2, 4, 9, 3)],
+    [(10, 1, 2, 4, 1), (20, 1, 3, 8, 2), (27, 2, 4, 12, 3)],
 )
-def test_TransformerBlock_output_size(
+def test_TransformerBlock_output_properties(
     vocab_size: int,
     batch_size: int,
     context_size: int,
@@ -24,4 +24,5 @@ def test_TransformerBlock_output_size(
     model = GPT2(vocab_size, embed_dim, context_size, n_tsfmr_blocks)
     out_batch = model(tokens_batch)
 
-    assert out_batch.size() == torch.Size((batch_size, context_size, embed_dim))
+    assert out_batch.size() == torch.Size((batch_size, context_size, vocab_size))
+    assert torch.all(torch.isreal(out_batch))

--- a/tests/test_gpt2.py
+++ b/tests/test_gpt2.py
@@ -129,6 +129,4 @@ def test_GP2Tokenizer_tokenizes_text(text: str):
 
     assert tokenizer.text2tokens(text) == tokens
     assert tokenizer.tokens2text(tokens) == text
-
     assert tokenizer(text) == tokenizer.text2tokens(text)
-    assert tokenizer.train() is tokenizer

--- a/tests/test_gpt2.py
+++ b/tests/test_gpt2.py
@@ -5,7 +5,7 @@ import re
 import pytest
 import torch
 
-from llmz.gpt2 import GPT2, GPT2Config, GPT2ConfigError, GPT2InferenceError
+from llmz.gpt2 import GPT2, GPT2Config, GPT2ConfigError, GPT2InferenceError, GPT2Tokenizer
 
 
 @pytest.mark.parametrize(
@@ -111,3 +111,12 @@ def test_GPT2Config_command_line_representation():
         r"^GPT2Config\(\n(\s\s[a-zA-Z0-9_]+=([\.\d]+|True|False|\".*\")+,\n)+\)$"
     )
     assert re.match(expected_output_pattern, config.__repr__()) is not None
+
+
+@pytest.mark.parametrize("text", ["foo bar", "My name is Alex"])
+def test_GP2Tokenizer_tokenizes_text(text: str):
+    tokenizer = GPT2Tokenizer()
+    tokens = tokenizer.text2tokens(text)
+    assert len(tokens) > 1
+    assert isinstance(tokens[0], int)
+    assert tokenizer.tokens2text(tokens) == text

--- a/tests/test_gpt2.py
+++ b/tests/test_gpt2.py
@@ -5,7 +5,7 @@ import re
 import pytest
 import torch
 
-from llmz.gpt2 import GPT2, GPT2InferenceError
+from llmz.gpt2 import GPT2, GPT2Config, GPT2ConfigError, GPT2InferenceError
 
 
 @pytest.mark.parametrize(
@@ -36,3 +36,49 @@ def test_TransformerBlock_raises_error_for_incomputable_inference():
     with pytest.raises(GPT2InferenceError, match=expected_err_msg):
         x = torch.ones((1, 6))
         model(x)
+
+
+def test_GPT2Config_validates_fields():
+    # valid config
+    try:
+        GPT2Config(
+            vocab_size=1000,
+            embed_dim=800,
+            context_size=100,
+            n_tsfmr_blocks=4,
+            n_attn_heads=8,
+            dropout=0.2,
+            qkv_bias=False,
+        )
+        assert True
+    except Exception:
+        assert False
+
+    # invalid config
+    expected_msg = re.escape(
+        "invalid GPT2 parameters: vocab_size is not > 0\n embed_dim % n_attn_heads != 0"
+    )
+    with pytest.raises(GPT2ConfigError, match=expected_msg):
+        GPT2Config(
+            vocab_size=-1000,
+            embed_dim=801,
+            context_size=100,
+            n_tsfmr_blocks=4,
+            n_attn_heads=8,
+            dropout=0.2,
+            qkv_bias=False,
+        )
+
+def test_GPT2Config_kwarg_expansion():
+        try:
+            config = GPT2Config(
+                vocab_size=1000,
+                embed_dim=800,
+                context_size=100,
+                n_tsfmr_blocks=4,
+                n_attn_heads=8,
+            )
+            GPT2(**config)
+            assert True
+        except Exception:
+            assert False

--- a/tests/test_gpt2.py
+++ b/tests/test_gpt2.py
@@ -1,8 +1,27 @@
 """Test for GP2 model."""
 
+import pytest
+import torch
+
 from llmz.gpt2 import GPT2
 
 
-def test_GPT2_output_shape():
-    model = GPT2()
-    assert model is not None
+@pytest.mark.parametrize(
+    "vocab_size, batch_size, context_size, embed_dim, n_tsfmr_blocks",
+    [(10, 1, 2, 9, 1), (20, 1, 2, 9, 2), (27, 2, 4, 9, 3)],
+)
+def test_TransformerBlock_output_size(
+    vocab_size: int,
+    batch_size: int,
+    context_size: int,
+    embed_dim: int,
+    n_tsfmr_blocks: int,
+):
+    tokens_batch = torch.randint(
+        0, vocab_size, (batch_size, context_size), dtype=torch.int32
+    )
+
+    model = GPT2(vocab_size, embed_dim, context_size, n_tsfmr_blocks)
+    out_batch = model(tokens_batch)
+
+    assert out_batch.size() == torch.Size((batch_size, context_size, embed_dim))

--- a/tests/test_gpt2.py
+++ b/tests/test_gpt2.py
@@ -1,9 +1,11 @@
 """Test for GP2 model."""
 
+import re
+
 import pytest
 import torch
 
-from llmz.gpt2 import GPT2
+from llmz.gpt2 import GPT2, GPT2InferenceError
 
 
 @pytest.mark.parametrize(
@@ -26,3 +28,11 @@ def test_TransformerBlock_output_properties(
 
     assert out_batch.size() == torch.Size((batch_size, context_size, vocab_size))
     assert torch.all(torch.isreal(out_batch))
+
+
+def test_TransformerBlock_raises_error_for_incomputable_inference():
+    model = GPT2(vocab_size=5, embed_dim=5, context_size=5, n_tsfmr_blocks=1)
+    expected_err_msg = re.escape("seq_len (6) > context_size (5)")
+    with pytest.raises(GPT2InferenceError, match=expected_err_msg):
+        x = torch.ones((1, 6))
+        model(x)

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -10,7 +10,9 @@ from llmz.components.transformers import TransformerBlockGPT2
 @pytest.mark.parametrize(
     "batch_size, context_size, dim_in", [(1, 2, 9), (1, 2, 9), (2, 4, 9)]
 )
-def test_TransformerBlock_output_size(batch_size: int, context_size: int, dim_in: int):
+def test_TransformerBlock_output_properties(
+    batch_size: int, context_size: int, dim_in: int
+):
     tokens_batch = torch.ones(batch_size, context_size, dtype=torch.int32)
     embeddings_batch = nn.Embedding(10, dim_in)(tokens_batch)
 
@@ -18,3 +20,4 @@ def test_TransformerBlock_output_size(batch_size: int, context_size: int, dim_in
     out_batch = transformer(embeddings_batch)
 
     assert out_batch.size() == torch.Size((batch_size, context_size, dim_in))
+    assert torch.all(torch.isreal(out_batch))


### PR DESCRIPTION
## Added

- `src/llmz/gpt2.py` - An implementation of OpenAI's GPT2 model.
- `tests/test_gpt2.py` - Tests for the GPT2 implementation.

## Modified

- `docs/api.md` - Added `gpt2.py` to the API reference docs.
- `src/llmz/components/attention.py` - Improve docstring and correct typos.
- `src/llmz/components/transformers.py` - Correct typo.
- `tests/test_attention.py` - Add `nan` output testing.
- `tests/test_transformers.py` - Add `nan` output testing.
